### PR TITLE
Implement cron job functionality with ping service and configuration management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,17 @@ SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USERNAME=your_email@gmail.com
 SMTP_PASSWORD=your_app_password
+
+# Cron Jobs Configuration
+# URL to ping periodically (leave empty to disable ping job)
+PING_URL=https://your-app.herokuapp.com/health
+
+# Cron schedule for ping job (default: every 5 minutes)
+# Format: minute hour day month day-of-week
+# Examples:
+# */5 * * * *     - Every 5 minutes
+# */10 * * * *    - Every 10 minutes  
+# */30 * * * *    - Every 30 minutes
+# 0 */1 * * *     - Every hour
+# 0 9 * * 1-5     - Every weekday at 9:00 AM
+PING_SCHEDULE=*/5 * * * *

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,106 @@
+# GitHub Copilot Instructions for API21
+
+## Architecture Overview
+
+This is a Go Fiber REST API with clean architecture patterns. Key components:
+
+- **Entry Point**: `cmd/server/main.go` - Sets up Fiber app, middleware, cron jobs, and graceful shutdown
+- **Internal Package Structure**: Config → Routes → Handlers → Models, with middleware and utilities supporting all layers
+- **Cron Jobs**: `internal/cron_jobs/` - Automatic URL ping service with configurable scheduling
+- **Test Structure**: All tests consolidated in `./tests/` directory using external black-box testing
+
+## Critical Development Workflows
+
+### Primary Development Commands
+```bash
+./run.sh dev          # Hot reload with Air (phttps://api21-s5nh.onrender.com/referred for development)
+make dev              # Alternative hot reload
+go run cmd/server/main.go  # Direct execution
+```
+
+### Testing Strategy
+- **Location**: All tests in `./tests/` directory (not package-level `_test.go` files)
+- **Pattern**: External testing using `package tests` and importing `api21/internal/*`
+- **Run Tests**: `go test ./tests/...` or `./run.sh test`
+- **Integration Tests**: Full HTTP server testing with actual Fiber app instances
+
+### Build and Deploy
+```bash
+./run.sh build        # Single platform build
+make build-all        # Multi-platform builds (Linux/Windows/macOS)
+docker-compose up     # Full stack (API + PostgreSQL + Redis + PgAdmin)
+```
+
+## Project-Specific Patterns
+
+### Configuration Management
+- **Pattern**: Centralized config in `internal/config/config.go` with struct-based env loading
+- **Example**: `cfg := config.Load()` loads all environment variables with defaults
+- **Cron Jobs Config**: `CronJobsConfig` embedded in main config struct
+
+### Error Handling
+- **Pattern**: Fiber's built-in error handler with custom JSON responses
+- **Location**: Error handler defined in `cmd/server/main.go` Fiber config
+- **Format**: Returns `{"error": "message"}` with appropriate HTTP status codes
+
+### Route Organization
+- **Pattern**: Route groups in `internal/routes/routes.go` with handler delegation
+- **Structure**: `/api/v1` prefix → resource groups (`/users`, `/items`) → HTTP methods
+- **Handler Location**: All handlers in `internal/handlers/handlers.go`
+
+### Cron Jobs Integration
+- **Manager Pattern**: `cron_jobs.NewManager()` centralizes all scheduled tasks
+- **Environment Driven**: Jobs start only if `PING_URL` is set
+- **Graceful Shutdown**: Cron manager stops automatically on app termination
+- **Monitoring**: `/cron/status` endpoint shows job status and next run times
+
+## Key Integration Points
+
+### Database (GORM)
+- **ORM**: GORM with PostgreSQL, but database layer is in `internal/database/`
+- **Models**: Defined in `internal/models/models.go`
+- **Connection**: Auto-migration on startup (when database is configured)
+
+### Middleware Stack
+- **Order**: Logger → Recovery → CORS → Custom middleware
+- **Custom**: Request ID, rate limiting, API key validation in `internal/middleware/`
+- **Configuration**: CORS allows all origins with standard headers
+
+### Environment Variables
+- **Required**: None (all have defaults)
+- **Cron Jobs**: `PING_URL` (required for ping job), `PING_SCHEDULE` (optional, defaults to "*/5 * * * *")
+- **Database**: Standard `DB_*` prefixed variables
+- **Loading**: Uses `joho/godotenv` with graceful fallback if no `.env` file
+
+## Development Environment
+
+### Hot Reload Setup
+- **Tool**: Air (github.com/air-verse/air)
+- **Config**: Air config in project root enables automatic rebuilds
+- **Command**: `./run.sh dev` or `make dev`
+
+### Docker Development Stack
+- **Services**: API (port 3000), PostgreSQL (5432), Redis (6379), PgAdmin (8080)
+- **PgAdmin Access**: admin@api21.com / admin
+- **Network**: Services communicate via `api21-network`
+
+## Testing Conventions
+
+### Test File Naming
+- **Pattern**: `{component}_test.go` in `./tests/` directory
+- **Package**: Always `package tests` with imports to `api21/internal/*`
+- **Example**: `tests/cron_jobs_test.go` tests `internal/cron_jobs` package
+
+### HTTP Testing Pattern
+```go
+app := fiber.New()
+routes.SetupRoutes(app)
+req := httptest.NewRequest("GET", "/api/v1/users", nil)
+resp, _ := app.Test(req)
+```
+
+### Environment Variable Testing
+```go
+os.Setenv("KEY", "value")
+defer os.Unsetenv("KEY")
+```

--- a/examples/cron_example.go
+++ b/examples/cron_example.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"api21/internal/cron_jobs"
+)
+
+// Example of how to use the cron jobs independently
+func main() {
+	// Set environment variables for demonstration
+	os.Setenv("PING_URL", "https://httpbin.org/get")
+	os.Setenv("PING_SCHEDULE", "*/1 * * * *") // Every minute
+
+	// Create and start the cron manager
+	manager := cron_jobs.NewManager()
+
+	log.Println("Starting cron job example...")
+	if err := manager.Start(); err != nil {
+		log.Fatalf("Failed to start cron jobs: %v", err)
+	}
+
+	// Print status
+	status := manager.GetStatus()
+	log.Printf("Cron jobs status: %+v", status)
+
+	// Test ping manually
+	if err := cron_jobs.TestPing("https://httpbin.org/get"); err != nil {
+		log.Printf("Manual ping failed: %v", err)
+	}
+
+	// Wait for interrupt signal
+	sigterm := make(chan os.Signal, 1)
+	signal.Notify(sigterm, syscall.SIGINT, syscall.SIGTERM)
+
+	log.Println("Cron jobs are running. Press Ctrl+C to stop...")
+	<-sigterm
+
+	log.Println("Stopping cron jobs...")
+	manager.Stop()
+	log.Println("Example completed.")
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.51.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import "os"
 type Config struct {
 	Port     string
 	Database DatabaseConfig
+	CronJobs CronJobsConfig
 }
 
 type DatabaseConfig struct {
@@ -14,6 +15,11 @@ type DatabaseConfig struct {
 	Password string
 	DBName   string
 	SSLMode  string
+}
+
+type CronJobsConfig struct {
+	PingURL      string
+	PingSchedule string
 }
 
 func Load() *Config {
@@ -26,6 +32,10 @@ func Load() *Config {
 			Password: getEnv("DB_PASSWORD", ""),
 			DBName:   getEnv("DB_NAME", "api21_db"),
 			SSLMode:  getEnv("DB_SSLMODE", "disable"),
+		},
+		CronJobs: CronJobsConfig{
+			PingURL:      getEnv("PING_URL", ""),
+			PingSchedule: getEnv("PING_SCHEDULE", "*/5 * * * *"), // Default: every 5 minutes
 		},
 	}
 }

--- a/internal/cron_jobs/README.md
+++ b/internal/cron_jobs/README.md
@@ -1,0 +1,131 @@
+# Cron Jobs
+
+This package provides cron job functionality for the API21 application.
+
+## Features
+
+- **Ping Job**: Automatically pings a configured URL at specified intervals
+- **Manager**: Centralized management of all cron jobs
+- **Graceful Shutdown**: Properly stops all cron jobs when the application shuts down
+
+## Configuration
+
+The cron jobs are configured using environment variables:
+
+### Ping Job
+
+- `PING_URL`: The URL to ping (required for the ping job to start)
+- `PING_SCHEDULE`: Cron schedule expression (default: `*/5 * * * *` - every 5 minutes)
+
+### Schedule Format
+
+The schedule uses standard cron syntax with 5 fields:
+
+```
+* * * * *
+│ │ │ │ │
+│ │ │ │ └─── Day of week (0-7, Sunday = 0 or 7)
+│ │ │ └───── Month (1-12)
+│ │ └─────── Day of month (1-31)
+│ └───────── Hour (0-23)
+└─────────── Minute (0-59)
+```
+
+### Examples
+
+- `*/5 * * * *` - Every 5 minutes
+- `0 */1 * * *` - Every hour
+- `0 9 * * 1-5` - Every weekday at 9:00 AM
+- `0 0 * * 0` - Every Sunday at midnight
+
+## Usage
+
+### Environment Variables
+
+Create a `.env` file or set environment variables:
+
+```bash
+# Required for ping job to start
+PING_URL=https://your-app.herokuapp.com/health
+
+# Optional: Custom schedule (default is every 5 minutes)
+PING_SCHEDULE="*/10 * * * *"
+```
+
+### API Endpoints
+
+- `GET /cron/status` - Get the status of all cron jobs
+
+### Example Response
+
+```json
+{
+  "manager_started": true,
+  "ping_job": {
+    "ping_url": "https://your-app.herokuapp.com/health",
+    "schedule": "*/5 * * * *",
+    "running": true,
+    "next_run": "2025-08-29 10:35:00"
+  }
+}
+```
+
+## Use Cases
+
+### Keep Heroku App Awake
+
+Heroku free tier apps go to sleep after 30 minutes of inactivity. You can use the ping job to keep your app awake:
+
+```bash
+# Set your app's health endpoint as the ping URL
+PING_URL=https://your-app.herokuapp.com/health
+
+# Ping every 25 minutes to prevent sleeping
+PING_SCHEDULE="*/25 * * * *"
+```
+
+### Health Monitoring
+
+Monitor external services or APIs:
+
+```bash
+# Monitor an external API
+PING_URL=https://api.external-service.com/health
+
+# Check every 2 minutes
+PING_SCHEDULE="*/2 * * * *"
+```
+
+### Webhook Notifications
+
+Send periodic notifications to webhook endpoints:
+
+```bash
+# Webhook URL
+PING_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+
+# Daily at 9 AM
+PING_SCHEDULE="0 9 * * *"
+```
+
+## Implementation Details
+
+- Uses the `github.com/robfig/cron/v3` library for scheduling
+- HTTP client has a 30-second timeout for ping requests
+- Logs all ping attempts and their results
+- Gracefully handles missing environment variables
+- Thread-safe manager with mutex protection
+
+## Testing
+
+Run the tests:
+
+```bash
+go test ./internal/cron_jobs/...
+```
+
+The tests cover:
+- Job initialization with different configurations
+- Manager start/stop functionality
+- Status reporting
+- Environment variable handling

--- a/internal/cron_jobs/manager.go
+++ b/internal/cron_jobs/manager.go
@@ -1,0 +1,78 @@
+package cron_jobs
+
+import (
+	"log"
+	"sync"
+)
+
+// Manager handles all cron jobs in the application
+type Manager struct {
+	pingJob *PingJob
+	mu      sync.RWMutex
+	started bool
+}
+
+// NewManager creates a new cron jobs manager
+func NewManager() *Manager {
+	return &Manager{
+		pingJob: NewPingJob(),
+	}
+}
+
+// Start starts all cron jobs
+func (m *Manager) Start() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.started {
+		log.Println("Cron jobs already started")
+		return nil
+	}
+
+	log.Println("Starting cron jobs...")
+
+	// Start ping job
+	if err := m.pingJob.Start(); err != nil {
+		return err
+	}
+
+	m.started = true
+	log.Println("All cron jobs started successfully")
+	return nil
+}
+
+// Stop stops all cron jobs
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.started {
+		return
+	}
+
+	log.Println("Stopping cron jobs...")
+
+	// Stop ping job
+	m.pingJob.Stop()
+
+	m.started = false
+	log.Println("All cron jobs stopped")
+}
+
+// GetStatus returns the status of all cron jobs
+func (m *Manager) GetStatus() map[string]interface{} {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return map[string]interface{}{
+		"manager_started": m.started,
+		"ping_job":        m.pingJob.GetStatus(),
+	}
+}
+
+// GetPingJob returns the ping job instance
+func (m *Manager) GetPingJob() *PingJob {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.pingJob
+}

--- a/internal/cron_jobs/ping_job.go
+++ b/internal/cron_jobs/ping_job.go
@@ -1,0 +1,114 @@
+package cron_jobs
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+type PingJob struct {
+	cron     *cron.Cron
+	pingURL  string
+	schedule string
+}
+
+// NewPingJob creates a new ping job instance
+func NewPingJob() *PingJob {
+	// Get URL and schedule from environment variables
+	pingURL := os.Getenv("PING_URL")
+	schedule := os.Getenv("PING_SCHEDULE")
+
+	// Default schedule: every 5 minutes
+	if schedule == "" {
+		schedule = "*/5 * * * *" // Every 5 minutes
+	}
+
+	return &PingJob{
+		cron:     cron.New(),
+		pingURL:  pingURL,
+		schedule: schedule,
+	}
+}
+
+// Start begins the cron job
+func (p *PingJob) Start() error {
+	if p.pingURL == "" {
+		log.Println("PING_URL environment variable not set, ping job will not start")
+		return nil
+	}
+
+	log.Printf("Starting ping job for URL: %s with schedule: %s", p.pingURL, p.schedule)
+
+	// Add the ping job to cron scheduler
+	_, err := p.cron.AddFunc(p.schedule, p.pingEndpoint)
+	if err != nil {
+		return fmt.Errorf("failed to add ping job to cron: %w", err)
+	}
+
+	// Start the cron scheduler
+	p.cron.Start()
+	log.Println("Ping job started successfully")
+
+	return nil
+}
+
+// Stop stops the cron job
+func (p *PingJob) Stop() {
+	if p.cron != nil {
+		p.cron.Stop()
+		log.Println("Ping job stopped")
+	}
+}
+
+// pingEndpoint performs the actual ping to the URL
+func (p *PingJob) pingEndpoint() {
+	log.Printf("Pinging URL: %s", p.pingURL)
+
+	// Create HTTP client with timeout
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	// Make the request
+	resp, err := client.Get(p.pingURL)
+	if err != nil {
+		log.Printf("Failed to ping %s: %v", p.pingURL, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Log the response status
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		log.Printf("Successfully pinged %s - Status: %d", p.pingURL, resp.StatusCode)
+	} else {
+		log.Printf("Ping to %s returned non-success status: %d", p.pingURL, resp.StatusCode)
+	}
+}
+
+// GetStatus returns the current status of the ping job
+func (p *PingJob) GetStatus() map[string]interface{} {
+	return map[string]interface{}{
+		"ping_url": p.pingURL,
+		"schedule": p.schedule,
+		"running":  p.cron != nil,
+		"next_run": p.getNextRun(),
+	}
+}
+
+// getNextRun returns the next scheduled run time
+func (p *PingJob) getNextRun() string {
+	if p.cron == nil {
+		return "Not scheduled"
+	}
+
+	entries := p.cron.Entries()
+	if len(entries) == 0 {
+		return "No entries"
+	}
+
+	return entries[0].Next.Format("2006-01-02 15:04:05")
+}

--- a/internal/cron_jobs/utils.go
+++ b/internal/cron_jobs/utils.go
@@ -1,0 +1,56 @@
+package cron_jobs
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// PingJobWithConfig creates a ping job with custom configuration
+func PingJobWithConfig(url, schedule string) *PingJob {
+	return &PingJob{
+		pingURL:  url,
+		schedule: schedule,
+	}
+}
+
+// ValidateSchedule validates if the cron schedule is valid
+func ValidateSchedule(schedule string) error {
+	tempCron := cron.New()
+	_, err := tempCron.AddFunc(schedule, func() {})
+	return err
+}
+
+// TestPing performs a one-time ping to test connectivity
+func TestPing(url string) error {
+	log.Printf("Testing ping to URL: %s", url)
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to ping %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		log.Printf("✅ Successfully pinged %s - Status: %d", url, resp.StatusCode)
+		return nil
+	}
+
+	return fmt.Errorf("ping to %s returned non-success status: %d", url, resp.StatusCode)
+}
+
+// GetConfigFromEnv returns the current environment configuration
+func GetConfigFromEnv() map[string]string {
+	return map[string]string{
+		"PING_URL":      os.Getenv("PING_URL"),
+		"PING_SCHEDULE": os.Getenv("PING_SCHEDULE"),
+	}
+}

--- a/tests/cron_jobs_test.go
+++ b/tests/cron_jobs_test.go
@@ -1,0 +1,156 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"api21/internal/cron_jobs"
+)
+
+func TestNewPingJob(t *testing.T) {
+	// Set environment variables for testing
+	os.Setenv("PING_URL", "https://httpbin.org/get")
+	os.Setenv("PING_SCHEDULE", "*/1 * * * *")
+	defer func() {
+		os.Unsetenv("PING_URL")
+		os.Unsetenv("PING_SCHEDULE")
+	}()
+
+	job := cron_jobs.NewPingJob()
+
+	status := job.GetStatus()
+	if status["ping_url"] != "https://httpbin.org/get" {
+		t.Errorf("Expected ping URL to be 'https://httpbin.org/get', got '%v'", status["ping_url"])
+	}
+
+	if status["schedule"] != "*/1 * * * *" {
+		t.Errorf("Expected schedule to be '*/1 * * * *', got '%v'", status["schedule"])
+	}
+}
+
+func TestPingJobDefaultSchedule(t *testing.T) {
+	// Clear environment variables
+	os.Unsetenv("PING_URL")
+	os.Unsetenv("PING_SCHEDULE")
+
+	job := cron_jobs.NewPingJob()
+	status := job.GetStatus()
+
+	if status["schedule"] != "*/5 * * * *" {
+		t.Errorf("Expected default schedule to be '*/5 * * * *', got '%v'", status["schedule"])
+	}
+}
+
+func TestPingJobStart(t *testing.T) {
+	// Test with empty URL (should not start)
+	os.Unsetenv("PING_URL")
+	job := cron_jobs.NewPingJob()
+
+	err := job.Start()
+	if err != nil {
+		t.Errorf("Expected no error when URL is empty, got: %v", err)
+	}
+
+	// Test with valid URL
+	os.Setenv("PING_URL", "https://httpbin.org/get")
+	os.Setenv("PING_SCHEDULE", "0 0 1 1 *") // Once a year to avoid actual pings in test
+	defer func() {
+		os.Unsetenv("PING_URL")
+		os.Unsetenv("PING_SCHEDULE")
+	}()
+
+	job = cron_jobs.NewPingJob()
+	err = job.Start()
+	if err != nil {
+		t.Errorf("Expected no error when starting job, got: %v", err)
+	}
+
+	// Clean up
+	job.Stop()
+}
+
+func TestPingJobGetStatus(t *testing.T) {
+	os.Setenv("PING_URL", "https://example.com")
+	os.Setenv("PING_SCHEDULE", "*/5 * * * *")
+	defer func() {
+		os.Unsetenv("PING_URL")
+		os.Unsetenv("PING_SCHEDULE")
+	}()
+
+	job := cron_jobs.NewPingJob()
+	status := job.GetStatus()
+
+	if status["ping_url"] != "https://example.com" {
+		t.Errorf("Expected ping_url to be 'https://example.com', got '%v'", status["ping_url"])
+	}
+
+	if status["schedule"] != "*/5 * * * *" {
+		t.Errorf("Expected schedule to be '*/5 * * * *', got '%v'", status["schedule"])
+	}
+}
+
+func TestCronJobsManager(t *testing.T) {
+	manager := cron_jobs.NewManager()
+
+	// Test initial state
+	status := manager.GetStatus()
+	if status["manager_started"] != false {
+		t.Errorf("Expected manager to not be started initially")
+	}
+
+	// Test start
+	err := manager.Start()
+	if err != nil {
+		t.Errorf("Expected no error when starting manager, got: %v", err)
+	}
+
+	status = manager.GetStatus()
+	if status["manager_started"] != true {
+		t.Errorf("Expected manager to be started after Start()")
+	}
+
+	// Test stop
+	manager.Stop()
+	status = manager.GetStatus()
+	if status["manager_started"] != false {
+		t.Errorf("Expected manager to be stopped after Stop()")
+	}
+}
+
+func TestCronJobsUtilities(t *testing.T) {
+	// Test config retrieval
+	os.Setenv("PING_URL", "https://test.example.com")
+	os.Setenv("PING_SCHEDULE", "*/10 * * * *")
+	defer func() {
+		os.Unsetenv("PING_URL")
+		os.Unsetenv("PING_SCHEDULE")
+	}()
+
+	config := cron_jobs.GetConfigFromEnv()
+	if config["PING_URL"] != "https://test.example.com" {
+		t.Errorf("Expected PING_URL to be 'https://test.example.com', got '%s'", config["PING_URL"])
+	}
+
+	if config["PING_SCHEDULE"] != "*/10 * * * *" {
+		t.Errorf("Expected PING_SCHEDULE to be '*/10 * * * *', got '%s'", config["PING_SCHEDULE"])
+	}
+
+	// Test schedule validation
+	validSchedules := []string{
+		"*/5 * * * *",
+		"0 9 * * 1-5",
+		"0 0 1 1 *",
+	}
+
+	for _, schedule := range validSchedules {
+		if err := cron_jobs.ValidateSchedule(schedule); err != nil {
+			t.Errorf("Expected schedule '%s' to be valid, got error: %v", schedule, err)
+		}
+	}
+
+	// Test invalid schedule
+	invalidSchedule := "invalid schedule"
+	if err := cron_jobs.ValidateSchedule(invalidSchedule); err == nil {
+		t.Errorf("Expected schedule '%s' to be invalid, but got no error", invalidSchedule)
+	}
+}


### PR DESCRIPTION
Introduce a cron job manager that pings a specified URL at configurable intervals. Add environment variable support for URL and schedule, along with endpoints for checking job status and testing pings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a built-in cron job to periodically ping a configurable URL.
  - Introduced PING_URL and PING_SCHEDULE environment variables (defaults to every 5 minutes).
  - Added endpoints: GET /cron/status and POST /cron/test-ping.

- Documentation
  - Updated environment template with cron config and examples.
  - Added a comprehensive guide covering architecture, cron jobs, setup, and testing.

- Tests
  - Added tests for cron manager lifecycle, schedule validation, and env handling.

- Chores
  - Added cron scheduler dependency.
  - Included a runnable example demonstrating cron usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->